### PR TITLE
Check for tric before general purpose ci

### DIFF
--- a/dev/setup/src/utils.php
+++ b/dev/setup/src/utils.php
@@ -366,11 +366,12 @@ function is_tric() {
  * @return string The current run context, one of `ci`, `tric` or `default`.
  */
 function run_context() {
-	if ( is_ci() ) {
-		return 'ci';
-	}
 	if ( is_tric() ) {
 		return 'tric';
+	}
+
+	if ( is_ci() ) {
+		return 'ci';
 	}
 
 	return 'default';


### PR DESCRIPTION
When running tric within the context of GitHub Actions, `is_ci()` will _always_ resolve to `true`, preventing a proper identification of a tric execution. This change orders the run context analysis by specificity.