### PR TITLE
Add new command to disable build-prompts

### DIFF
--- a/dev/.env.tric
+++ b/dev/.env.tric
@@ -25,6 +25,9 @@ TRIC_PLUGINS_DIR=./_plugins
 # The path from which to read WordPress core code from.
 TRIC_WP_DIR=./_wordpress
 
+# The build-prompt mode of tric. Set to `0` to avoid prompting/defaulting prompts during CLI operations.
+TRIC_BUILD_PROMPT=1
+
 # The interactive mode of tric. Set to `0` to avoid prompts during CLI operations.
 TRIC_INTERACTIVE=1
 

--- a/dev/.env.tric
+++ b/dev/.env.tric
@@ -25,7 +25,7 @@ TRIC_PLUGINS_DIR=./_plugins
 # The path from which to read WordPress core code from.
 TRIC_WP_DIR=./_wordpress
 
-# The build-prompt mode of tric. Set to `0` to avoid prompting/defaulting prompts during CLI operations.
+# The build-prompt mode of tric. Set to `0` to avoid prompting/defaulting prompts for composer/npm builds during CLI operations.
 TRIC_BUILD_PROMPT=1
 
 # The interactive mode of tric. Set to `0` to avoid prompts during CLI operations.

--- a/dev/setup/src/commands/build-prompt.php
+++ b/dev/setup/src/commands/build-prompt.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tribe\Test;
+
+if ( $is_help ) {
+	echo "Activates or deactivates whether or not composer/npm build prompts should be provided.\n";
+	echo PHP_EOL;
+	echo colorize( "signature: <light_cyan>{$cli_name} build-prompt (on|off|status)</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} build-prompt on</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} build-prompt off</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} build-prompt status</light_cyan>\n" );
+	return;
+}
+
+$interactive_args = args( [ 'toggle' ], $args( '...' ), 0 );
+
+tric_handle_build_prompt( $interactive_args );
+
+echo colorize( "\n\nToggle this setting by using: <light_cyan>tric build-prompt [on|off]</light_cyan>\n" );
+echo colorize( "- on:  commands will prompt for composer/npm installs.\n" );
+echo colorize( "- off: commands will NOT prompt for composer/npm installs.\n" );

--- a/dev/setup/src/commands/init.php
+++ b/dev/setup/src/commands/init.php
@@ -37,7 +37,9 @@ if ( null !== $branch ) {
 
 setup_plugin_tests( $plugin );
 
-tric_maybe_run_composer_install( $plugin );
-tric_maybe_run_npm_install( $plugin );
+if ( getenv( 'TRIC_BUILD_PROMPT' ) ) {
+	tric_maybe_run_composer_install( $plugin );
+	tric_maybe_run_npm_install( $plugin );
+}
 
 echo light_cyan( "Finished initializing {$plugin}\n" );

--- a/dev/setup/src/tric.php
+++ b/dev/setup/src/tric.php
@@ -383,6 +383,40 @@ function tric_wp_dir( $path = '' ) {
 }
 
 /**
+ * Prints the current build-prompt status to screen.
+ */
+function build_prompt_status() {
+	$enabled = getenv( 'TRIC_INTERACTIVE' );
+
+	echo 'Interactive status is: ' . ( $enabled ? light_cyan( 'on' ) : magenta( 'off' ) ) . PHP_EOL;
+}
+
+/**
+ * Handles the build-prompt command request.
+ *
+ * @param callable $args The closure that will produce the current interactive request arguments.
+ */
+function tric_handle_build_prompt( callable $args ) {
+	$run_settings_file = dev( '/.env.tric.run' );
+	$toggle            = $args( 'toggle', 'on' );
+
+	if ( 'status' === $toggle ) {
+		build_prompt_status();
+
+		return;
+	}
+
+	$value = 'on' === $toggle ? 1 : 0;
+	echo 'Build Prompt status: ' . ( $value ? light_cyan( 'on' ) : magenta( 'off' ) );
+
+	if ( $value === (int) getenv( 'TRIC_BUILD_PROMPT' ) ) {
+		return;
+	}
+
+	write_env_file( $run_settings_file, [ 'TRIC_BUILD_PROMPT' => $value ], true );
+}
+
+/**
  * Prints the current interactive status to screen.
  */
 function interactive_status() {

--- a/dev/tric
+++ b/dev/tric
@@ -59,6 +59,7 @@ Available commands:
 <light_cyan>update</light_cyan>         Updates the tool and the images used in its services.
 
 <yellow>Info:</yellow>
+<light_cyan>build-prompt</light_cyan>   Activates or deactivates whether or not composer/npm build prompts should be provided.
 <light_cyan>config</light_cyan>         Prints the stack configuration as interpolated from the environment.
 <light_cyan>debug</light_cyan>          Activates or deactivates {$cli_name} debug output or returns the current debug status.
 <light_cyan>help</light_cyan>           Displays this help message.
@@ -92,6 +93,7 @@ switch ( $subcommand ) {
 		break;
 	case 'airplane-mode':
 	case 'build':
+	case 'build-prompt':
 	case 'cc':
 	case 'cli':
 	case 'composer':


### PR DESCRIPTION
The build prompts occur during `tric init`. This setting disables that prompt so the sensible default of: `yes` can be disabled when desired by just suppressing the prompt. This is helpful in a CI context.

🎥 http://p.tri.be/gPfTTW