### PR TITLE
We need to exit with an error status if there is one.

### DIFF
--- a/dev/setup/src/commands/build.php
+++ b/dev/setup/src/commands/build.php
@@ -16,5 +16,7 @@ $service      = $service_args( 'service', '' );
 
 setup_id();
 // Run the command in the Codeception container, exit the same status as the process.
-$shell_args    = array_merge( [ 'build', $service ], $service_args( '...' ) );
-$status        = tric_realtime()( $shell_args );
+$shell_args = array_merge( [ 'build', $service ], $service_args( '...' ) );
+$status     = tric_realtime()( $shell_args );
+
+exit( $status );

--- a/dev/setup/src/commands/cc.php
+++ b/dev/setup/src/commands/cc.php
@@ -16,4 +16,6 @@ echo light_cyan( "Using {$using}\n" );
 
 setup_id();
 // Run the command in the Codeception container, exit the same status as the process.
-$status        = tric_realtime()( array_merge( [ 'run', '--rm', 'codeception' ], $args( '...' ) ) );
+$status = tric_realtime()( array_merge( [ 'run', '--rm', 'codeception' ], $args( '...' ) ) );
+
+exit( $status );

--- a/dev/setup/src/commands/cli.php
+++ b/dev/setup/src/commands/cli.php
@@ -13,4 +13,6 @@ if ( $is_help ) {
 setup_id();
 // Runs a wp-cli command in the stack, using the `cli` service.
 $command = $args( '...' );
-tric_realtime()( cli_command( $command ) );
+$status  = tric_realtime()( cli_command( $command ) );
+
+exit( $status );

--- a/dev/setup/src/commands/composer.php
+++ b/dev/setup/src/commands/composer.php
@@ -16,7 +16,12 @@ echo light_cyan( "Using {$using}\n" );
 
 setup_id();
 $composer_command = $args( '...' );
-tric_realtime()( array_merge( [ 'run', '--rm', 'composer' ], $composer_command ) );
+$status = tric_realtime()( array_merge( [ 'run', '--rm', 'composer' ], $composer_command ) );
+
+// If there is a status other than 0, we have an error. Bail.
+if ( $status ) {
+	exit( $status );
+}
 
 if ( ! file_exists( tric_plugins_dir( "{$using}/common" ) ) ) {
 	return;
@@ -27,9 +32,11 @@ if ( ask( "\nWould you like to run that composer command against common?", 'yes'
 
 	echo light_cyan( "Temporarily using " . tric_target() . "\n" );
 
-	tric_realtime()( array_merge( [ 'run', '--rm', 'composer' ], $composer_command ) );
+	$status = tric_realtime()( array_merge( [ 'run', '--rm', 'composer' ], $composer_command ) );
 
 	tric_switch_target( $using );
 
 	echo light_cyan( "Using " . tric_target() ." once again\n" );
 }
+
+exit( $status );

--- a/dev/setup/src/commands/config.php
+++ b/dev/setup/src/commands/config.php
@@ -11,4 +11,6 @@ if ( $is_help ) {
 
 $using = tric_target();
 setup_id();
-tric_realtime()( [ 'config' ] );
+$status = tric_realtime()( [ 'config' ] );
+
+exit( $status );

--- a/dev/setup/src/commands/down.php
+++ b/dev/setup/src/commands/down.php
@@ -9,4 +9,6 @@ if ( $is_help ) {
 	return;
 }
 
-tric_realtime()( [ 'down', '--volumes', '--remove-orphans' ] );
+$status = tric_realtime()( [ 'down', '--volumes', '--remove-orphans' ] );
+
+exit( $status );

--- a/dev/setup/src/commands/npm.php
+++ b/dev/setup/src/commands/npm.php
@@ -16,7 +16,12 @@ echo light_cyan( "Using {$using}\n" );
 
 setup_id();
 $npm_command   = $args( '...' );
-tric_realtime()( array_merge( [ 'run', '--rm', 'npm' ], $npm_command ) );
+$status = tric_realtime()( array_merge( [ 'run', '--rm', 'npm' ], $npm_command ) );
+
+// If there is a status other than 0, we have an error. Bail.
+if ( $status ) {
+	exit( $status );
+}
 
 if ( ! file_exists( tric_plugins_dir( "{$using}/common" ) ) ) {
 	return;
@@ -27,9 +32,11 @@ if ( ask( "\nWould you like to run that npm command against common?", 'yes' ) ) 
 
 	echo light_cyan( "Temporarily using " . tric_target() . "\n" );
 
-	tric_realtime()( array_merge( [ 'run', '--rm', 'npm' ], $npm_command ) );
+	$status = tric_realtime()( array_merge( [ 'run', '--rm', 'npm' ], $npm_command ) );
 
 	tric_switch_target( $using );
 
 	echo light_cyan( "Using " . tric_target() ." once again\n" );
 }
+
+exit( $status );

--- a/dev/setup/src/commands/run.php
+++ b/dev/setup/src/commands/run.php
@@ -74,4 +74,6 @@ switch ( $available_configs_mask ) {
 $run_configuration = array_merge( [ 'run', '--rm', 'codeception', 'run' ], $config_files );
 
 // Finally run the command.
-tric_realtime()( array_merge( $run_configuration, $args( '...' ) ) );
+$status = tric_realtime()( array_merge( $run_configuration, $args( '...' ) ) );
+
+exit( $status );

--- a/dev/setup/src/commands/shell.php
+++ b/dev/setup/src/commands/shell.php
@@ -21,3 +21,5 @@ setup_id();
 // Run the command in the Codeception container, exit the same status as the process.
 $shell_args    = array_merge( [ 'run', '--rm', '--entrypoint', 'bash', $service ], $service_args( '...' ) );
 $status        = tric_realtime()( $shell_args );
+
+exit( $status );

--- a/dev/setup/src/commands/up.php
+++ b/dev/setup/src/commands/up.php
@@ -10,5 +10,7 @@ if ( $is_help ) {
 	return;
 }
 
-$service       = args( [ 'service' ], $args( '...' ), 0 )( 'service', 'wordpress' );
-tric_realtime()( [ 'up', '-d', $service ] );
+$service = args( [ 'service' ], $args( '...' ), 0 )( 'service', 'wordpress' );
+$status  = tric_realtime()( [ 'up', '-d', $service ] );
+
+exit( $status );


### PR DESCRIPTION
This ensures that if a command executed in the stack generates an error, we are relaying that for the tric command status.

This will allow CI-based environments to flag errors in command execution where appropriate.