### PR TITLE
Fix tric issues found while working in CI

### DIFF
--- a/dev/setup/src/commands/up.php
+++ b/dev/setup/src/commands/up.php
@@ -5,7 +5,7 @@ namespace Tribe\Test;
 if ( $is_help ) {
 	echo "Starts a container part of the stack.\n";
 	echo PHP_EOL;
-	echo colorize( "signature: <light_cyan>{$cli_name} up <service></service></light_cyan>\n" );
+	echo colorize( "signature: <light_cyan>{$cli_name} up <service></light_cyan>\n" );
 	echo colorize( "example: <light_cyan>{$cli_name} up adminer</light_cyan>" );
 	return;
 }

--- a/dev/setup/src/tric.php
+++ b/dev/setup/src/tric.php
@@ -59,14 +59,34 @@ function setup_tric_env( $root_dir ) {
 	if ( empty( $wp_dir ) ) {
 		$wp_dir = dev( '_wordpress' );
 	} elseif ( ! is_dir( $wp_dir ) ) {
-		$wp_dir = realpath( dev( ltrim( $wp_dir, './' ) ) );
+		$wp_dir_path = dev( ltrim( $wp_dir, './' ) );
+
+		if ( ! is_dir( $wp_dir_path ) && ! mkdir( $wp_dir_path ) && ! is_dir( $wp_dir_path ) ) {
+			// If the WordPress directory does not exist, then create it now.
+			echo magenta( "Cannot create the {$wp_dir_path} directory" );
+			exit( 1 );
+		}
+
+		$wp_dir = realpath( $wp_dir_path );
+	}
+
+	// Whatever the case, the WordPress directory should now exist.
+	if ( ! is_dir( $wp_dir ) ) {
+		echo magenta( "The WordPress directory ({$wp_dir}) does not exist." );
+		exit( 1 );
 	}
 
 	$plugins_dir = getenv( 'TRIC_PLUGINS_DIR' );
 	if ( empty( $plugins_dir ) ) {
 		$plugins_dir = dev( '_plugins' );
 	} elseif ( ! is_dir( $plugins_dir ) ) {
-		$plugins_dir = realpath( dev( ltrim( $plugins_dir, './' ) ) );
+		$plugin_dir_path = dev( ltrim( $plugins_dir, './' ) );
+
+		if ( ! is_dir( $plugin_dir_path ) && ! mkdir( $plugin_dir_path ) && ! is_dir( $plugin_dir_path ) ) {
+			echo magenta( "Cannot create the {$plugin_dir_path} directory." );
+			exit( 1 );
+		}
+		$plugins_dir = realpath( $plugin_dir_path );
 	}
 
 	putenv( 'TRIC_WP_DIR=' . $wp_dir );

--- a/dev/tric-stack.yml
+++ b/dev/tric-stack.yml
@@ -145,6 +145,8 @@ services:
       CODECEPTION_PROJECT_DIR: /var/www/html/wp-content/plugins/${TRIC_CURRENT_PROJECT:-test}
       # Whether to disable the XDebug extension in the Codeception container completely or not.
       XDEBUG_DISABLE: "${XDEBUG_DISABLE:-0}"
+      # After the WordPress container comes online, wait a further 3s to give it some boot-up time.
+      CODECEPTION_WAIT: 3
     depends_on:
       - wordpress
       - chrome

--- a/dev/tric-stack.yml
+++ b/dev/tric-stack.yml
@@ -19,7 +19,7 @@ services:
     networks:
       - tric
     environment:
-      # The `test` database is always present, no need to create it.
+      MYSQL_DATABASE: test
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
 
   wordpress:

--- a/dev/tric-stack.yml
+++ b/dev/tric-stack.yml
@@ -23,10 +23,8 @@ services:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
 
   wordpress:
-    build:
-      context: test/_containers/wordpress_debug
-      args:
-        WORDPRESS_BASE_CONTAINER: 'wordpress:latest'
+    # Fix the version of the WordPress image to avoid issues w/ out-of-date database dumps.
+    image: wordpress:5.4.1-apache
     networks:
       tric:
         # Allow the other containers to read this container with a pretty URL.


### PR DESCRIPTION
This fix is related to the work done for VE-15 as it highlighted a number of issues that became visible while running tests w/ `tric` in CI (GitHub Actions) context.

This fix is not ideal, but good enough to get the work done, [see here](https://github.com/moderntribe/events-virtual/runs/646319984?check_suite_focus=true).

What this fix does:

1. Leverage the `CODECEPTION_WAIT` support in the `codeception` container to wait an arbitrary 3s before running the tests; this will give the WordPress container script that scaffolds the WordPress installation time to scaffold it correctly; in _some_ instances the tests would run on a partially scaffolded installation.
2. Explicitly require the creation of the `test` database in the `db` service. This is done using the `MYSQL_DATABASE` env var and will ensure that we're not depending on a supposedly default container behavior to run the tests.
3. In the context of a CI run the `tric` tool will run on a freshly-cloned `moderntribe/products-test-automation` clone; we were not handling the initial setup of the `dev/_wordrpess` directory correctly.
4. Remove the use of the custom built WordPress container, for now, to rely on a fixed version of the official WordPress container. This removes, from the debugging in CI context, the "noise" generated by the possibly failing WordPress container build. 

THE Gotcha:

In `tric` stack configuration file we bind the current plugins directory to the `/var/www/html/wp-content/plugins` directory inside the container.  
On first run the directory will not exist and the WordPress container will scaffold the WordPress installation setting the user of the plugins directory to... `root`.
This would kill tests that would run as the `docker` user and would not, then, be able to access the files.
Simply spinning up the container first and then running the tests will fix the file mode issues.

This I will look at in another PR.