### PR TITLE
Fix more issues found while working with tric in CI/Linux context

### DIFF
--- a/dev/setup/src/commands/shell.php
+++ b/dev/setup/src/commands/shell.php
@@ -18,6 +18,12 @@ $using = tric_target();
 echo light_cyan( "Using {$using}\n" );
 
 setup_id();
-// Run the command in the Codeception container, exit the same status as the process.
-$shell_args    = array_merge( [ 'run', '--rm', '--entrypoint', 'bash', $service ], $service_args( '...' ) );
-$status        = tric_realtime()( $shell_args );
+
+if ( 'codeception' === $service ) {
+	// If the shell is for the `codeception` container, then use its built-in shell support.
+	$shell_args = array_merge( [ 'run', '--rm', $service, 'bash' ], $service_args( '...' ) );
+} else {
+	$shell_args = array_merge( [ 'run', '--rm', '--entrypoint', 'bash', $service ], $service_args( '...' ) );
+}
+
+$status = tric_realtime()( $shell_args );

--- a/dev/setup/src/tric.php
+++ b/dev/setup/src/tric.php
@@ -61,7 +61,12 @@ function setup_tric_env( $root_dir ) {
 	} elseif ( ! is_dir( $wp_dir ) ) {
 		$wp_dir_path = dev( ltrim( $wp_dir, './' ) );
 
-		if ( ! is_dir( $wp_dir_path ) && ! mkdir( $wp_dir_path ) && ! is_dir( $wp_dir_path ) ) {
+		if (
+			is_dir( basename( $wp_dir_path ) )
+			&& ! is_dir( $wp_dir_path )
+			&& ! mkdir( $wp_dir_path )
+			&& ! is_dir( $wp_dir_path )
+		) {
 			// If the WordPress directory does not exist, then create it now.
 			echo magenta( "Cannot create the {$wp_dir_path} directory" );
 			exit( 1 );
@@ -82,7 +87,12 @@ function setup_tric_env( $root_dir ) {
 	} elseif ( ! is_dir( $plugins_dir ) ) {
 		$plugin_dir_path = dev( ltrim( $plugins_dir, './' ) );
 
-		if ( ! is_dir( $plugin_dir_path ) && ! mkdir( $plugin_dir_path ) && ! is_dir( $plugin_dir_path ) ) {
+		if (
+			is_dir( basename( $plugin_dir_path ) )
+			&& ! is_dir( $plugin_dir_path )
+			&& ! mkdir( $plugin_dir_path )
+			&& ! is_dir( $plugin_dir_path )
+		) {
 			echo magenta( "Cannot create the {$plugin_dir_path} directory." );
 			exit( 1 );
 		}

--- a/dev/setup/src/utils.php
+++ b/dev/setup/src/utils.php
@@ -307,18 +307,16 @@ function the_fatality() {
  *                an empty string to indicate the host machine IP address could not be obtained.
  */
 function host_ip( $os = 'Linux' ) {
-	switch ( $os ) {
-		case 'Linux':
-			$command = "ip route | grep docker0 | cut -f9 -d' '";
-			exec( $command, $output, $status );
-			if ( 0 !== (int) $status ) {
-				echo magenta( "Cannot get the host machine IP address using '${command}'\n" );
-				exit( 1 );
-			}
-			$host_ip = trim( $output[0] );
-			break;
-		default:
-			$host_ip = 'host.docker.internal';
+	if ( $os === 'Linux' ) {
+		$command = "ip route | grep docker0 | cut -f9 -d' '";
+		exec( $command, $output, $status );
+		if ( 0 !== (int) $status ) {
+			echo magenta( "Cannot get the host machine IP address using '${command}'\n" );
+			exit( 1 );
+		}
+		$host_ip = trim( $output[0] );
+	} else {
+		$host_ip = 'host.docker.internal';
 	}
 
 	return $host_ip;


### PR DESCRIPTION
This PR is a follow-up to #59 that addresses more issues I've found while
using `tric` on Linux.

I will add more fixes as I go, currently:

1. Use the shell provided by the `codeception` service when using `tric shell`.
2. Refactor code to reduce complexity and fix host IP address fetching on Linux.
3. Irrobust the check for the WP and plugins directory creation; this could results in `tric` attempting to create weird directories paths when `tric` configuration is ported over from another installation (e.g. rsynced from my macOS machine to my Linux machine).