### PR TITLE
This fix ensures that bolded text is properly bolded

### DIFF
--- a/dev/setup/src/utils.php
+++ b/dev/setup/src/utils.php
@@ -493,7 +493,9 @@ function ask( $question, $default = null ) {
 	if ( empty( $is_interactive ) ) {
 		$value = $default;
 	} else {
-		$value = readline( $prompt . ' ' );
+		// Using echo rather than the parameter for the readline() for prompting due to a terminal window incompatibility.
+		echo $prompt;
+		$value = readline();
 	}
 
 	if ( $is_boolean ) {


### PR DESCRIPTION
I tested this on multiple terminals with both bash and zsh within my Ubuntu environment. Consistently, the `readline()` function butchered the formatting of the text, resulting in:

```
[1mThe text to bold[0m
```

Echoing separately resolves this issue.

![Screenshot from 2020-05-09 22-08-23](https://user-images.githubusercontent.com/430385/81489287-a5c67e00-9241-11ea-9b4c-5fed90606c27.png)
