### PR TITLE
Add object-cache support

### DIFF
--- a/dev/setup/src/commands/cache.php
+++ b/dev/setup/src/commands/cache.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Handles the `cache` command.
+ *
+ * @var bool     $is_help Whether we're handling an `help` request on this command or not.
+ * @var \Closure $args    The argument map closure, as produced by the `args` function.
+ */
+
+use function Tribe\Test\args;
+use function Tribe\Test\check_status_or;
+use function Tribe\Test\check_status_or_exit;
+use function Tribe\Test\cli_command;
+use function Tribe\Test\colorize;
+use function Tribe\Test\magenta;
+use function Tribe\Test\tric_process;
+use function Tribe\Test\tric_realtime;
+
+if ( $is_help ) {
+	echo "Activates and deactivates object cache support, returns the current object cache status.\n";
+	echo PHP_EOL;
+	echo colorize( "signature: <light_cyan>{$cli_name} cache (status|on|off)</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} cache status</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} cache on</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} cache off</light_cyan>" );
+
+	return;
+}
+
+$cache_args = args( [ 'toggle' ], $args( '...' ), 0 );
+$toggle     = $cache_args( 'toggle', 'status' );
+
+// Ensure the plugin is installed.
+check_status_or(
+	tric_process()( cli_command( [ 'plugin', 'is-installed', 'redis-cache' ] ) ),
+	static function () {
+		$status = tric_realtime()( cli_command( [ 'plugin', 'install', 'redis-cache' ] ) );
+		if ( 0 !== $status ) {
+			echo magenta( "Installation of redis-cache plugin failed; see above.\n" );
+			exit( 1 );
+		}
+	}
+);
+
+// Ensure the plugin is activated.
+check_status_or(
+	tric_process()( cli_command( [ 'plugin', 'is-active', 'redis-cache' ] ) ),
+	static function () {
+		check_status_or_exit( tric_process()( cli_command( [ 'plugin', 'activate', 'redis-cache' ] ) ) );
+	}
+);
+
+switch ( $toggle ) {
+	default:
+	case 'status':
+		tric_realtime()( cli_command( [ 'redis', 'status' ] ) );
+		break;
+	case 'on':
+		check_status_or_exit( tric_process()( cli_command( [ 'redis', 'enable' ] ) ) );
+		tric_realtime()( cli_command( [ 'redis', 'status' ] ) );
+		break;
+	case 'off':
+		check_status_or_exit( tric_process()( cli_command( [ 'redis', 'disable' ] ) ) );
+		tric_realtime()( cli_command( [ 'redis', 'status' ] ) );
+		break;
+}

--- a/dev/setup/src/commands/run.php
+++ b/dev/setup/src/commands/run.php
@@ -34,6 +34,17 @@ setup_id();
 // Run the command in the Codeception container.
 $root = tric_plugins_dir( tric_target( true ) );
 
+// Object-cache is disruptive in the context of tests; remove the object cache drop-in before running the tests.
+$object_cache_dropin = tric_wp_dir( 'wp-content/object-cache.php' );
+if ( file_exists( $object_cache_dropin ) ) {
+	echo "Removing the object cache drop-in file before tests...\n";
+	if ( ! unlink( $object_cache_dropin ) ) {
+		echo magenta( "Failed to remove the {$object_cache_dropin} file.\n" );
+		exit( 1 );
+	}
+	echo "Object cache drop-in file removed.\n";
+}
+
 /*
  * Check what configuration files we've got available.
  * Depending on the what we have apply them in this order: dist, local, tric.

--- a/dev/setup/src/tric.php
+++ b/dev/setup/src/tric.php
@@ -818,32 +818,3 @@ function switch_plugin_branch( $branch, $plugin = null ) {
 		exit( 1 );
 	}
 }
-
-function cache_plugin_installed() {
-	$installed = true;
-
-	check_status_or(
-		tric_process()( cli_command( [ 'plugin', 'is-installed', 'airplane-mode' ] ) ),
-		static function () use ( &$installed ) {
-			$installed = false;
-		}
-	);
-
-	return $installed;
-}
-
-function cache_plugin_activated(){
-	if(!cache_plugin_installed()){
-		return false;
-	}
-	tric_realtime()(['cli','redis','status']);
-}
-
-function install_cache_plugin(){
-	check_status_or(
-		tric_process()( cli_command( [ 'plugin', 'is-installed', 'airplane-mode' ] ) ),
-		static function () use ( &$installed ) {
-			$installed = false;
-		}
-	);
-}

--- a/dev/setup/src/tric.php
+++ b/dev/setup/src/tric.php
@@ -62,7 +62,7 @@ function setup_tric_env( $root_dir ) {
 		$wp_dir_path = dev( ltrim( $wp_dir, './' ) );
 
 		if (
-			is_dir( basename( $wp_dir_path ) )
+			is_dir( dirname( $wp_dir_path ) )
 			&& ! is_dir( $wp_dir_path )
 			&& ! mkdir( $wp_dir_path )
 			&& ! is_dir( $wp_dir_path )
@@ -817,4 +817,33 @@ function switch_plugin_branch( $branch, $plugin = null ) {
 		echo magenta( "Could not restore working directory {$cwd}\n" );
 		exit( 1 );
 	}
+}
+
+function cache_plugin_installed() {
+	$installed = true;
+
+	check_status_or(
+		tric_process()( cli_command( [ 'plugin', 'is-installed', 'airplane-mode' ] ) ),
+		static function () use ( &$installed ) {
+			$installed = false;
+		}
+	);
+
+	return $installed;
+}
+
+function cache_plugin_activated(){
+	if(!cache_plugin_installed()){
+		return false;
+	}
+	tric_realtime()(['cli','redis','status']);
+}
+
+function install_cache_plugin(){
+	check_status_or(
+		tric_process()( cli_command( [ 'plugin', 'is-installed', 'airplane-mode' ] ) ),
+		static function () use ( &$installed ) {
+			$installed = false;
+		}
+	);
 }

--- a/dev/tric
+++ b/dev/tric
@@ -48,8 +48,9 @@ Available commands:
 <light_cyan>init</light_cyan>           Initializes a plugin for use in tric.
 <light_cyan>composer</light_cyan>       Runs a Composer command in the stack.
 <light_cyan>npm</light_cyan>            Runs an npm command in the stack.
-<light_cyan>xdebug</light_cyan>         Activates and deactivated XDebug in the stack, returns the current XDebug status or sets its values.
+<light_cyan>xdebug</light_cyan>         Activates and deactivates XDebug in the stack, returns the current XDebug status or sets its values.
 <light_cyan>airplane-mode</light_cyan>  Activates or deactivates the airplane-mode plugin.
+<light_cyan>cache</light_cyan>          Activates and deactivates object cache support, returns the current object cache status.
 
 <yellow>Advanced Usage:</yellow>
 <light_cyan>cc</light_cyan>             Runs a Codeception command in the stack, the equivalent of <light_cyan>'codecept ...'</light_cyan>.
@@ -94,6 +95,7 @@ switch ( $subcommand ) {
 	case 'airplane-mode':
 	case 'build':
 	case 'build-prompt':
+	case 'cache':
 	case 'cc':
 	case 'cli':
 	case 'composer':

--- a/dev/tric-stack.yml
+++ b/dev/tric-stack.yml
@@ -34,6 +34,7 @@ services:
       - "wordpress.test:172.${TRIC_TEST_SUBNET:-28}.1.1"
     depends_on:
       - db
+      - redis
     # Run the container as the host user and group.
     # Apache will run as the same user and permission issues with WordPress generated files should not arise.
     user: "${DOCKER_RUN_UID:-}:${DOCKER_RUN_GID:-}"
@@ -58,6 +59,8 @@ services:
         $$url    = isset( $$_SERVER['HTTP_HOST'] ) ? $$_SERVER['HTTP_HOST'] : 'wordpress.test';
         define( 'WP_HOME', $$scheme . '://' . $$url );
         define( 'WP_SITEURL', $$scheme . '://' . $$url );
+        define( 'WP_REDIS_HOST', 'redis' );
+        define( 'WP_REDIS_PORT', 6379 );
       # Configure this to debug the tests with XDebug.
       # Map the `dev/_wordpress` directory to `/var/www/html' directory in your IDE of choice.
       # Map the `dev/_plugins` directory to `/plugins` directory in your IDE of choice.
@@ -191,3 +194,20 @@ services:
       ADMINER_DEFAULT_SERVER: db
     ports:
       - "9080:8080"
+
+  redis:
+    image: redis
+    networks:
+      tric:
+    ports:
+      # Expose Redis port on port 8379 of localhost.
+      - "8379:6379"
+
+  redis-cli:
+    image: redis
+    networks:
+      tric:
+    depends_on:
+      - redis
+    entrypoint: ["redis-cli","-h redis","-p 6379"]
+    command: ["--version"]


### PR DESCRIPTION
This PR:

1. adds the `cache` command to `tric`; currently a bit ugly but working, we can refine in a next iteration
2. adds the `redis` and `redis-cli` services to the stack 
3. fixes an issue w/ tric and the WordPress directory creation

[Screencap](https://drive.google.com/open?id=16PAEgoX8BFMSQsR62NEaP2czApyLR7iG&authuser=luca@tri.be&usp=drive_fs)

fixes #47