### PR TITLE
Set the TRIBE_TRIC env variable when running Codeception tests

### DIFF
--- a/dev/tric-stack.yml
+++ b/dev/tric-stack.yml
@@ -148,6 +148,8 @@ services:
       XDEBUG_DISABLE: "${XDEBUG_DISABLE:-0}"
       # After the WordPress container comes online, wait a further 3s to give it some boot-up time.
       CODECEPTION_WAIT: 3
+      # Declare that we are in a tric context so plugins can set custom test configs.
+      TRIBE_TRIC: 1
     depends_on:
       - wordpress
       - chrome


### PR DESCRIPTION
This will allow us to take specific actions in test config setups as needed.

Example: PUE uses a Square One-like setup but when run in tric, the standard WP environment is used.