### PR TITLE
Correctly build shell aliases

### DIFF
--- a/dev/setup/shell.php
+++ b/dev/setup/shell.php
@@ -21,3 +21,87 @@ function wp_cli( array $command = [ 'version' ], $quiet = false ) {
 
 	return $output;
 }
+
+/**
+ * Returns the current terminal window/tab lines and columns.
+ *
+ * The check is OS-aware and will use, on Windows, the correct command.
+ *
+ * @return array<int> The number of, respectively, lines and columns.
+ */
+function get_terminal_lines_cols() {
+	$lines   = null;
+	$columns = null;
+
+	if ( 'Windows' === os() ) {
+		exec( 'mode', $output, $status );
+
+		if ( 0 !== $status ) {
+			// We cannot fetch information, bail.
+			return [ $lines, $columns ];
+		}
+
+		/*
+		 * Output looks like this, it's localized in the OS language.
+		 *
+		 * Status for device CON:
+		 * ----------------------
+		 *     Lines:          9001
+		 *     Columns:        120
+		 *     Keyboard rate:  31
+		 *     Keyboard delay: 1
+		 *     Code page:      437
+		 */
+
+		foreach ( $output as $line ) {
+			// Since the output might be localized to the OS language, we need to parse the format, not the words.
+			if ( ! preg_match( '/\\s{4}\\w+:\\s+(?<val>\\d+)/', $line, $m ) ) {
+				continue;
+			}
+
+			$lines   = $lines ? $lines : $m['val'];
+			$columns = $m['val'];
+		}
+	} else {
+		exec( 'resize', $output, $status );
+
+		if ( 0 !== $status ) {
+			// We cannot fetch information, bail.
+			return [ $lines, $columns ];
+		}
+
+		foreach ( $output as $line ) {
+			if ( ! preg_match( '/(?<key>(COLUMNS|LINES))=(?<val>[0-9]+)/', $line, $m ) ) {
+				continue;
+			}
+			$key    = strtolower( $m['key'] );
+			${$key} = (int) $m['val'];
+		}
+	}
+
+	return [ $lines, $columns ];
+}
+
+/**
+ * Set up the terminal, by means of environment vars, to improve the output and behavior of tric processes.
+ *
+ * @param bool $force Whether to force the re-fetch and re-set of the terminal or to skip if already done.
+ */
+function setup_terminal( $force = false ) {
+	static $setup;
+
+	if ( ! $force && $setup ) {
+		return;
+	}
+
+	$setup = true;
+
+	// Setup the LINES and COLUMNS env vars to make sure commands will not wrap on themselves during execution.
+	list( $lines, $columns ) = get_terminal_lines_cols();
+	if ( ! empty( $lines ) ) {
+		putenv( "LINES={$lines}" );
+	}
+	if ( ! empty( $columns ) ) {
+		putenv( "COLUMNS={$columns}" );
+	}
+}

--- a/dev/setup/src/commands/shell.php
+++ b/dev/setup/src/commands/shell.php
@@ -21,9 +21,9 @@ setup_id();
 
 if ( 'codeception' === $service ) {
 	// If the shell is for the `codeception` container, then use its built-in shell support.
-	$shell_args = array_merge( [ 'run', '--rm', $service, 'bash' ], $service_args( '...' ) );
+	$shell_args = array_merge( [ 'run', '--rm', $service, 'shell' ], $service_args( '...' ) );
 } else {
-	$shell_args = array_merge( [ 'run', '--rm', '--entrypoint', 'bash', $service ], $service_args( '...' ) );
+	$shell_args = array_merge( [ 'run', '--rm', '--entrypoint', 'shell', $service ], $service_args( '...' ) );
 }
 
 // Run the command in the container, exit the same status as the process.

--- a/dev/setup/src/process.php
+++ b/dev/setup/src/process.php
@@ -43,6 +43,8 @@ function process_realtime( $command ) {
 
 	echo PHP_EOL;
 
+	setup_terminal();
+
 	passthru( escapeshellcmd( $command ), $status );
 
 	return (int) $status;

--- a/dev/tric-stack.yml
+++ b/dev/tric-stack.yml
@@ -152,6 +152,9 @@ services:
       XDEBUG_DISABLE: "${XDEBUG_DISABLE:-0}"
       # Declare that we are in a tric context so plugins can set custom test configs.
       TRIBE_TRIC: 1
+      # Let's set the lines and columns number explicitly to have the shell mirror the current one.
+      LINES: "${LINES:-24}"
+      COLUMNS: "${COLUMNS:-80}"
     depends_on:
       - wordpress
       - chrome

--- a/dev/tric-stack.yml
+++ b/dev/tric-stack.yml
@@ -144,10 +144,12 @@ services:
       XDEBUG_CONFIG: "idekey=${XDK:-tric} remote_enable=${XDE:-1} remote_host=${XDH:-host.docker.internal} remote_port=${XDP:-9001}"
       # Move to the target directory before running the command from the plugins directory.
       CODECEPTION_PROJECT_DIR: /var/www/html/wp-content/plugins/${TRIC_CURRENT_PROJECT:-test}
-      # Whether to disable the XDebug extension in the Codeception container completely or not.
-      XDEBUG_DISABLE: "${XDEBUG_DISABLE:-0}"
+      # When running the container in shell mode (using the tric `shell` command), then use this CC configuration.
+      CODECEPTION_SHELL_CONFIG: "-c codeception.tric.yml"
       # After the WordPress container comes online, wait a further 3s to give it some boot-up time.
       CODECEPTION_WAIT: 3
+      # Whether to disable the XDebug extension in the Codeception container completely or not.
+      XDEBUG_DISABLE: "${XDEBUG_DISABLE:-0}"
       # Declare that we are in a tric context so plugins can set custom test configs.
       TRIBE_TRIC: 1
     depends_on:


### PR DESCRIPTION
When using the `tric shell` command to run tests from within the Codeception service the configuration file used by the `cr` and `c` aliases would not be the correct one.

Specifically it would run:

```bash
vendor/bin/codecept run ...
vendor/bin/codecept ...
```

Ignoring `tric` custom configuration file entirely.

This fix makes it so that the aliases will be set up correctly to run:

```bash
vendor/bin/codecept run -c codeception.tric.yml ...
vendor/bin/codecept -c codeception.tric.yml ...
```

[Screencap](https://drive.google.com/open?id=16WiDkThh3NMsE5lSQdRWoU4uCvi9905I&authuser=luca@tri.be&usp=drive_fs)

I've added a second quality-of-life improvement in this PR to avoid the shell opened w/ the `tric shell` command from wrapping on itself:

[Screencap](https://drive.google.com/open?id=16Ya1sH1K16qkR0QQoZ7Skb83ByQdKj_w&authuser=luca@tri.be&usp=drive_fs)

> Note: run `tric update` to pull the newest images version and test this.