### PR TITLE
Properly exit with `1` when codeception test fails

### DIFF
--- a/dev/setup/src/commands/run.php
+++ b/dev/setup/src/commands/run.php
@@ -85,12 +85,7 @@ switch ( $available_configs_mask ) {
 $run_configuration = array_merge( [ 'run', '--rm', 'codeception', 'run' ], $config_files );
 
 // Finally run the command.
-$status = tric_realtime()( array_merge( $run_configuration, $args( '...' ) ) );
-
+$status     = tric_realtime()( array_merge( $run_configuration, $args( '...' ) ) );
 $has_failed = file_exists( $root . '/tests/_output/failed' );
 
-if ( $status || $has_failed ) {
-	exit( 1 );
-}
-
-exit( $status );
+exit( $status || $has_failed );

--- a/dev/setup/src/commands/run.php
+++ b/dev/setup/src/commands/run.php
@@ -87,4 +87,10 @@ $run_configuration = array_merge( [ 'run', '--rm', 'codeception', 'run' ], $conf
 // Finally run the command.
 $status = tric_realtime()( array_merge( $run_configuration, $args( '...' ) ) );
 
+$has_failed = file_exists( $root . '/tests/_output/failed' );
+
+if ( $status || $has_failed ) {
+	exit( 1 );
+}
+
 exit( $status );


### PR DESCRIPTION
This modifies the results of the `tric run` command to look at both the exit status _and_ the existence of the `tests/_output/failed` file to determine if the tests succeeded or failed.

:movie_camera: http://p.tri.be/4rLaVb